### PR TITLE
Fix plugin installation mechanism and add ldap plugin support

### DIFF
--- a/attributes/plugin.rb
+++ b/attributes/plugin.rb
@@ -1,3 +1,9 @@
 default['sonarqube']['plugin']['mirror'] = 'https://sonarsource.bintray.com/Distribution'
 
 default['sonarqube']['plugin']['dir'] = "/opt/sonarqube-#{node['sonarqube']['version']}/extensions/plugins"
+
+# hash with plugin:version pairs like
+# default['sonarqube']['plugin']['list'] = { 'ldap' => '2.1.0.507'}
+# plugin that is mentioned enables its configuration
+# (in sonar we cannot disable plugin we can either install it or uninstall it)
+default['sonarqube']['plugin']['list'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,6 +65,8 @@ template '/etc/init.d/sonarqube' do
   )
 end
 
+include_recipe 'sonarqube::plugins'
+
 service 'sonarqube' do
   supports restart: true, reload: false, status: true
   action [:enable, :start]

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -1,0 +1,6 @@
+node['sonarqube']['plugin']['list'].each_pair do |k, v|
+  sonarqube_plugin k do
+    version v
+    action :install
+  end
+end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -12,6 +12,13 @@ action :install do
     action :nothing
   end
 
+  # we need to remove previous plugin versions first
+  Dir['plugin_file_name_wildcard'].each do |path|
+    file ::File.expand_path(path) do
+      action :delete
+    end
+  end
+
   remote_file plugin_path do
     source plugin_url
     mode 0755
@@ -46,4 +53,9 @@ end
 
 def plugin_file_name
   "sonar-#{plugin_name}-plugin-#{version}.jar"
+end
+
+def plugin_file_name_wildcard
+  plugin_file_name_without_version = "sonar-#{plugin_name}-plugin-.*"
+  ::File.join(sonarqube_plugin_dir, plugin_file_name_without_version)
 end

--- a/templates/default/ldap_plugin.conf.erb
+++ b/templates/default/ldap_plugin.conf.erb
@@ -1,0 +1,8 @@
+sonar.security.realm=<%= node['sonarqube']['security']['realm'] %>
+ldap.url=<%= node['ldap']['url'] %>
+ldap.user.baseDn=<%= node['ldap']['user']['baseDn'] %>
+ldap.user.realNameAttribute=<%= node['ldap']['user']['realNameAttribute'] %>
+ldap.user.emailAttribute=<%= node['ldap']['user']['emailAttribute'] %>
+ldap.group.baseDn=<%= node['ldap']['group']['baseDn'] %>
+ldap.group.idAttribute=<%= node['ldap']['group']['idAttribute'] %>
+ldap.group.request=<%= node['ldap']['group']['request'] %>

--- a/templates/default/sonar.properties.erb
+++ b/templates/default/sonar.properties.erb
@@ -185,3 +185,8 @@ sonar.rails.dev=<%= node['sonarqube']['rails']['dev'] %>
 <% node['sonarqube']['extra_properties'].each do |p| %>
 <%= p %>
 <% end %>
+
+# add LDAP plugin configuration
+<% if !node['sonarqube']['plugin']['list']['ldap'].nil? -%>
+ <%= render "ldap_plugin.conf.erb" %>
+<% end -%>


### PR DESCRIPTION
There was a bug in plugin installation (at least with sonar 6.3.1). In case that plugin was already installed, plugin install with newer version will end up with two plugin jars and sonar will fail to run.

This commit fixes this issue

Also it allows to use ldap plugin with sonar