### PR TITLE
Comment out any properties that have a 'nil' value

### DIFF
--- a/libraries/config_helper.rb
+++ b/libraries/config_helper.rb
@@ -1,0 +1,22 @@
+module ConfigHelper
+  def self.property(node, key)
+    return nil unless key.is_a?(String) and not key.empty?
+
+    # transform the key into a 'path' into the node structure
+    config_path = key.split('.')
+
+    # if a key starts with 'sonar.', this is excluded from the config 'path'
+    config_path = config_path.drop(1) if config_path[0] == 'sonar'
+
+    # All configuration keys are read from node['sonarqube']
+    config_path = config_path.unshift('sonarqube')
+
+    # If path is [some, config, key], this will eval 'node['some']['config']['key']'
+    value = eval("node['" +  config_path.join("']['") + "'] rescue nil")
+
+    # comment out the value if it's an explicit nil value
+    prefix = value == nil ? '# ' : ''
+
+    "#{prefix}#{key}=#{value}"
+  end
+end

--- a/spec/unit/libraries/confg_helper_spec.rb
+++ b/spec/unit/libraries/confg_helper_spec.rb
@@ -1,0 +1,60 @@
+require_relative '../../../libraries/config_helper'
+
+describe ConfigHelper do
+  describe '#property' do
+
+    let(:node) do
+      {
+          'sonarqube' => {
+              'jdbc' => {
+                  'username' => 'sonar',
+                  'password' => nil,
+                  'url' => 'jdbc://something'
+              },
+              'http' => {
+                  'proxyHost' => nil,
+                  'proxyPort' => 9128
+              }
+          }
+      }
+    end
+
+    it 'returns nil when called with a key nil' do
+      expect(ConfigHelper.property(node, nil)).to eq nil
+    end
+
+    it 'returns nil when called with a key that is not a String' do
+      expect(ConfigHelper.property(node, {})).to eq nil
+    end
+
+    describe 'called with key starting with \'sonar.\'' do
+
+      it 'returns a commented out property for non existing keys' do
+        expect(ConfigHelper.property(node, 'sonar.does.not.exist')).to eq '# sonar.does.not.exist='
+      end
+
+      it 'returns a commented out property for a key that is explicitly nil ' do
+        expect(ConfigHelper.property(node, 'sonar.jdbc.password')).to eq '# sonar.jdbc.password='
+      end
+
+      it 'looks up the value in the node structure' do
+        expect(ConfigHelper.property(node, 'sonar.jdbc.username')).to eq 'sonar.jdbc.username=sonar'
+      end
+    end
+
+    describe 'called with key not starting with \'sonar.\'' do
+
+      it 'returns a commented out property for non existing keys' do
+        expect(ConfigHelper.property(node, 'does.not.exist')).to eq '# does.not.exist='
+      end
+
+      it 'returns a commented out property for a key that is explicitly nil ' do
+        expect(ConfigHelper.property(node, 'http.proxyHost')).to eq '# http.proxyHost='
+      end
+
+      it 'looks up the value in the node structure' do
+        expect(ConfigHelper.property(node, 'http.proxyPort')).to eq 'http.proxyPort=9128'
+      end
+    end
+  end
+end

--- a/templates/default/sonar.properties.erb
+++ b/templates/default/sonar.properties.erb
@@ -20,28 +20,28 @@
 
 # Permissions to create tables, indices and triggers must be granted to JDBC user.
 # The schema must be created first.
-sonar.jdbc.username=<%= node['sonarqube']['jdbc']['username'] %>
-sonar.jdbc.password=<%= node['sonarqube']['jdbc']['password'] %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.username') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.password') %>
 
 #----- Embedded database H2
 # Note: it does not accept connections from remote hosts, so the
 # SonarQube server and the maven plugin must be executed on the same host.
 
 # Database URL
-sonar.jdbc.url=<%= node['sonarqube']['jdbc']['url'] %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.url') %>
 
 # directory containing H2 database files. By default it's the /data directory in the SonarQube installation.
-sonar.embeddedDatabase.dataDir=<%= node['sonarqube']['embeddedDatabase']['dataDir'] %>
+<%= ConfigHelper.property(node, 'sonar.embeddedDatabase.dataDir') %>
 # H2 embedded database server listening port, defaults to 9092
-sonar.embeddedDatabase.port=<%= node['sonarqube']['embeddedDatabase']['port'] %>
+<%= ConfigHelper.property(node, 'sonar.embeddedDatabase.port') %>
 
 #----- Connection pool settings
-sonar.jdbc.maxActive=<%= node['sonarqube']['jdbc']['maxActive'] %>
-sonar.jdbc.maxIdle=<%= node['sonarqube']['jdbc']['maxIdle'] %>
-sonar.jdbc.minIdle=<%= node['sonarqube']['jdbc']['minIdle'] %>
-sonar.jdbc.maxWait=<%= node['sonarqube']['jdbc']['maxWait'] %>
-sonar.jdbc.minEvictableIdleTimeMillis=<%= node['sonarqube']['jdbc']['minEvictableIdleTimeMillis'] %>
-sonar.jdbc.timeBetweenEvictionRunsMillis=<%= node['sonarqube']['jdbc']['timeBetweenEvictionRunsMillis'] %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.maxActive') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.maxIdle') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.minIdle') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.maxWait') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.minEvictableIdleTimeMillis') %>
+<%= ConfigHelper.property(node, 'sonar.jdbc.timeBetweenEvictionRunsMillis') %>
 
 
 #--------------------------------------------------------------------------------------------------
@@ -50,93 +50,93 @@ sonar.jdbc.timeBetweenEvictionRunsMillis=<%= node['sonarqube']['jdbc']['timeBetw
 # Binding IP address. For servers with more than one IP address, this property specifies which
 # address will be used for listening on the specified ports.
 # By default, ports will be used on all IP addresses associated with the server.
-sonar.web.host=<%= node['sonarqube']['web']['host'] %>
+<%= ConfigHelper.property(node, 'sonar.web.host') %>
 
 # Web context. When set, it must start with forward slash (for example /sonarqube).
 # The default value is root context (empty value).
-sonar.web.context=<%= node['sonarqube']['web']['context'] %>
+<%= ConfigHelper.property(node, 'sonar.web.context') %>
 
 # TCP port for incoming HTTP connections. Disabled when value is -1.
-sonar.web.port=<%= node['sonarqube']['web']['port'] %>
+<%= ConfigHelper.property(node, 'sonar.web.port') %>
 
 # TCP port for incoming HTTPS connections. Disabled when value is -1 (default).
-sonar.web.https.port=<%= node['sonarqube']['web']['https']['port'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.port') %>
 
 # HTTPS - the alias used to for the server certificate in the keystore.
 # If not specified the first key read in the keystore is used.
-sonar.web.https.keyAlias=<%= node['sonarqube']['web']['https']['keyAlias'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keyAlias') %>
 
 # HTTPS - the password used to access the server certificate from the
 # specified keystore file. The default value is "changeit".
-sonar.web.https.keyPass=<%= node['sonarqube']['web']['https']['keyPass'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keyPass') %>
 
 # HTTPS - the pathname of the keystore file where is stored the server certificate.
 # By default, the pathname is the file ".keystore" in the user home.
 # If keystoreType doesn't need a file use empty value.
-sonar.web.https.keystoreFile=<%= node['sonarqube']['web']['https']['keystoreFile'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keystoreFile') %>
 
 # HTTPS - the password used to access the specified keystore file. The default
 # value is the value of sonar.web.https.keyPass.
-sonar.web.https.keystorePass=<%= node['sonarqube']['web']['https']['keystorePass'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keystorePass') %>
 
 # HTTPS - the type of keystore file to be used for the server certificate.
 # The default value is JKS (Java KeyStore).
-sonar.web.https.keystoreType=<%= node['sonarqube']['web']['https']['keystoreType'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keystoreType') %>
 
 # HTTPS - the name of the keystore provider to be used for the server certificate.
 # If not specified, the list of registered providers is traversed in preference order
 # and the first provider that supports the keystore type is used (see sonar.web.https.keystoreType).
-sonar.web.https.keystoreProvider=<%= node['sonarqube']['web']['https']['keystoreProvider'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.keystoreProvider') %>
 
 # HTTPS - the pathname of the truststore file which contains trusted certificate authorities.
 # By default, this would be the cacerts file in your JRE.
 # If truststoreFile doesn't need a file use empty value.
-sonar.web.https.truststoreFile=<%= node['sonarqube']['web']['https']['truststoreFile'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.truststoreFile') %>
 
-# HTTPS - the password used to access the specified truststore file. 
-sonar.web.https.truststorePass=<%= node['sonarqube']['web']['https']['truststorePass'] %>
+# HTTPS - the password used to access the specified truststore file.
+<%= ConfigHelper.property(node, 'sonar.web.https.truststorePass') %>
 
 # HTTPS - the type of truststore file to be used.
 # The default value is JKS (Java KeyStore).
-sonar.web.https.truststoreType=<%= node['sonarqube']['web']['https']['truststoreType'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.truststoreType') %>
 
 # HTTPS - the name of the truststore provider to be used for the server certificate.
 # If not specified, the list of registered providers is traversed in preference order
 # and the first provider that supports the truststore type is used (see sonar.web.https.truststoreType).
-sonar.web.https.truststoreProvider=<%= node['sonarqube']['web']['https']['truststoreProvider'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.truststoreProvider') %>
 
 # HTTPS - whether to enable client certificate authentication.
 # The default is false (client certificates disabled).
 # Other possible values are 'want' (certificates will be requested, but not required),
 # and 'true' (certificates are required).
-sonar.web.https.clientAuth=<%= node['sonarqube']['web']['https']['clientAuth'] %>
+<%= ConfigHelper.property(node, 'sonar.web.https.clientAuth') %>
 
 # The maximum number of connections that the server will accept and process at any given time.
 # When this number has been reached, the server will not accept any more connections until
 # the number of connections falls below this value. The operating system may still accept connections
 # based on the sonar.web.connections.acceptCount property. The default value is 50 for each
 # enabled connector.
-sonar.web.http.maxThreads=<%= node['sonarqube']['web']['http']['maxThreads'] %>
-sonar.web.https.maxThreads=<%= node['sonarqube']['web']['https']['maxThreads'] %>
+<%= ConfigHelper.property(node, 'sonar.web.http.maxThreads') %>
+<%= ConfigHelper.property(node, 'sonar.web.https.maxThreads') %>
 
 # The minimum number of threads always kept running. The default value is 5 for each
 # enabled connector.
-sonar.web.http.minThreads=<%= node['sonarqube']['web']['http']['minThreads'] %>
-sonar.web.https.minThreads=<%= node['sonarqube']['web']['https']['minThreads'] %>
+<%= ConfigHelper.property(node, 'sonar.web.http.minThreads') %>
+<%= ConfigHelper.property(node, 'sonar.web.https.minThreads') %>
 
 # The maximum queue length for incoming connection requests when all possible request processing
 # threads are in use. Any requests received when the queue is full will be refused.
 # The default value is 25 for each enabled connector.
-sonar.web.http.acceptCount=<%= node['sonarqube']['web']['http']['acceptCount'] %>
-sonar.web.https.acceptCount=<%= node['sonarqube']['web']['https']['acceptCount'] %>
+<%= ConfigHelper.property(node, 'sonar.web.http.acceptCount') %>
+<%= ConfigHelper.property(node, 'sonar.web.https.acceptCount') %>
 
 # Access logs are generated in the file logs/access.log. This file is rolled over when it's 5Mb.
 # An archive of 3 files is kept in the same directory.
 # Access logs are enabled by default.
-sonar.web.accessLogs.enable=<%= node['sonarqube']['web']['accessLogs']['enable'] %>
+<%= ConfigHelper.property(node, 'sonar.web.accessLogs.enable') %>
 
 # TCP port for incoming AJP connections. Disabled when value is -1.
-sonar.ajp.port=<%= node['sonarqube']['ajp']['port'] %>
+<%= ConfigHelper.property(node, 'sonar.ajp.port') %>
 
 
 
@@ -145,34 +145,34 @@ sonar.ajp.port=<%= node['sonarqube']['ajp']['port'] %>
 
 # The Update Center requires an internet connection to request http://update.sonarsource.org
 # It is enabled by default.
-sonar.updatecenter.activate=<%= node['sonarqube']['updatecenter']['activate'] %>
+<%= ConfigHelper.property(node, 'sonar.updatecenter.activate') %>
 
 # HTTP proxy (default none)
-http.proxyHost=<%= node['sonarqube']['http']['proxyHost'] %>
-http.proxyPort=<%= node['sonarqube']['http']['proxyPort'] %>
+<%= ConfigHelper.property(node, 'http.proxyHost') %>
+<%= ConfigHelper.property(node, 'http.proxyPort') %>
 
 # NT domain name if NTLM proxy is used
-http.auth.ntlm.domain=<%= node['sonarqube']['http']['auth']['ntlm']['domain'] %>
+<%= ConfigHelper.property(node, 'http.auth.ntlm.domain') %>
 
 # SOCKS proxy (default none)
-socksProxyHost=<%= node['sonarqube']['socksProxyHost'] %>
-socksProxyPort=<%= node['sonarqube']['socksProxyPort'] %>
+<%= ConfigHelper.property(node, 'socksProxyHost') %>
+<%= ConfigHelper.property(node, 'socksProxyPort') %>
 
 # proxy authentication. The 2 following properties are used for HTTP and SOCKS proxies.
-http.proxyUser=<%= node['sonarqube']['http']['proxyUser'] %>
-http.proxyPassword=<%= node['sonarqube']['http']['proxyPassword'] %>
+<%= ConfigHelper.property(node, 'http.proxyUser') %>
+<%= ConfigHelper.property(node, 'http.proxyPassword') %>
 
 
 #--------------------------------------------------------------------------------------------------
 # NOTIFICATIONS
 
 # Delay (in seconds) between processing of notification queue
-sonar.notifications.delay=<%= node['sonarqube']['notifications']['delay'] %>
+<%= ConfigHelper.property(node, 'sonar.notifications.delay') %>
 
 #--------------------------------------------------------------------------------------------------
 # PROFILING
 # Level of information displayed in the logs: NONE (default), BASIC (functional information) and FULL (functional and technical details)
-sonar.log.profilingLevel=<%= node['sonarqube']['log']['profilingLevel'] %>
+<%= ConfigHelper.property(node, 'sonar.log.profilingLevel') %>
 
 
 #--------------------------------------------------------------------------------------------------
@@ -180,7 +180,7 @@ sonar.log.profilingLevel=<%= node['sonarqube']['log']['profilingLevel'] %>
 # Only for debugging
 
 # Set to true to apply Ruby on Rails code changes on the fly
-sonar.rails.dev=<%= node['sonarqube']['rails']['dev'] %>
+<%= ConfigHelper.property(node, 'sonar.rails.dev') %>
 
 <% node['sonarqube']['extra_properties'].each do |p| %>
 <%= p %>


### PR DESCRIPTION
This is mainly needed for a 5.6+ upgrade that I intent to do. I noticed
that starting a 5.6.6 SonarQube with the old configuration would use the
embedded database even though I had configured a proper JDBC url.
Commenting out some of the embedded database configuration actually made
sure it used the configured (MySQL) jdbc url.

All configuration properties that are now set to 'nil' will be commented
out (but still visible in the configuration file)