### PR TITLE
only include SOCKS properties if set

### DIFF
--- a/templates/default/sonar.properties.erb
+++ b/templates/default/sonar.properties.erb
@@ -154,10 +154,12 @@ http.proxyPort=<%= node['sonarqube']['http']['proxyPort'] %>
 # NT domain name if NTLM proxy is used
 http.auth.ntlm.domain=<%= node['sonarqube']['http']['auth']['ntlm']['domain'] %>
 
+<% if node['sonarqube']['socksProxyHost'] -%>
 # SOCKS proxy (default none)
 socksProxyHost=<%= node['sonarqube']['socksProxyHost'] %>
 socksProxyPort=<%= node['sonarqube']['socksProxyPort'] %>
 
+<% end -%>
 # proxy authentication. The 2 following properties are used for HTTP and SOCKS proxies.
 http.proxyUser=<%= node['sonarqube']['http']['proxyUser'] %>
 http.proxyPassword=<%= node['sonarqube']['http']['proxyPassword'] %>


### PR DESCRIPTION
When using the postgres jdbc over TCP/IP, connections to the DB fail if an empty SOCKS proxy is configured.